### PR TITLE
Add Airflow DAG for distributed PySpark on Kubernetes

### DIFF
--- a/dags/12_distributed_pyspark_k8s_dag.py
+++ b/dags/12_distributed_pyspark_k8s_dag.py
@@ -1,0 +1,60 @@
+"""Airflow DAG launching a distributed PySpark job on Kubernetes."""
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+default_args = {
+    "owner": "data-team",
+    "depends_on_past": False,
+    "start_date": datetime(2024, 1, 1),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="12_distributed_pyspark_k8s_dag",
+    default_args=default_args,
+    description="Multi-node PySpark execution on Kubernetes",
+    schedule_interval=None,
+    catchup=False,
+    tags=["pyspark", "kubernetes", "distributed"],
+) as dag:
+
+    spark_submit_task = BashOperator(
+        task_id="spark_submit_distributed",
+        bash_command="""
+        /opt/spark/bin/spark-submit \
+        --master k8s://https://kubernetes.default.svc:443 \
+        --deploy-mode cluster \
+        --name pyspark-k8s-distributed \
+        --conf spark.kubernetes.namespace=default \
+        --conf spark.kubernetes.container.image=lotfinejad/airflow-pyspark:latest \
+        --conf spark.kubernetes.authenticate.driver.serviceAccountName=airflow-worker \
+        --conf spark.executor.instances=2 \
+        --conf spark.executor.memory=512m \
+        --conf spark.executor.cores=1 \
+        --conf spark.driver.memory=512m \
+        --conf spark.driver.cores=1 \
+        --conf spark.kubernetes.executor.deleteOnTermination=true \
+        --conf spark.kubernetes.submission.waitAppCompletion=true \
+        --conf spark.sql.shuffle.partitions=4 \
+        local:///opt/airflow/scripts/distributed_sales_job.py
+        """,
+        executor_config={
+            "pod_override": {
+                "spec": {
+                    "serviceAccountName": "airflow-worker",
+                    "containers": [
+                        {
+                            "name": "base",
+                            "resources": {
+                                "requests": {"memory": "1Gi", "cpu": "500m"},
+                                "limits": {"memory": "1Gi", "cpu": "500m"},
+                            },
+                        }
+                    ],
+                }
+            }
+        },
+    )

--- a/k8s/rbac.yaml
+++ b/k8s/rbac.yaml
@@ -38,6 +38,9 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["services", "secrets"]
+  verbs: ["create", "get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/scripts/distributed_sales_job.py
+++ b/scripts/distributed_sales_job.py
@@ -1,0 +1,33 @@
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, sum as spark_sum
+
+# Initialize SparkSession - settings mostly provided by spark-submit
+spark = SparkSession.builder.appName("distributed-sales-sum").getOrCreate()
+
+# Read all sales csv files to demonstrate distributed read
+sales_df = (
+    spark.read
+    .option("header", "true")
+    .option("inferSchema", "true")
+    .csv("/opt/airflow/scripts/datasets/sales_*.csv")
+)
+
+# Perform a simple distributed computation: total sales per category
+result_df = (
+    sales_df
+    .withColumn("total", col("Price") * col("Quantity_Sold"))
+    .groupBy("Category")
+    .agg(spark_sum("total").alias("category_sales"))
+)
+
+result_df.show()
+
+# Write output back to shared volume so it can be inspected later
+(
+    result_df.coalesce(1)
+    .write.mode("overwrite")
+    .option("header", "true")
+    .csv("/opt/airflow/scripts/output/sales_category_totals")
+)
+
+spark.stop()


### PR DESCRIPTION
## Summary
- Add DAG that submits a PySpark job to Kubernetes with a driver and two executor pods
- Include sample PySpark script performing distributed sales aggregation
- Expand RBAC to allow creation of services and secrets for Spark driver

## Testing
- `python -m py_compile dags/12_distributed_pyspark_k8s_dag.py scripts/distributed_sales_job.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac6676bb0832499103ed39ef167a7